### PR TITLE
Independent duration methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake", "~> 13.0"
 gem "minitest", "~> 5.16"
 
 gem "standard", "~> 1.3"
+
+gem "matrix", "~> 0.4.2"

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem "minitest", "~> 5.16"
 gem "standard", "~> 1.3"
 
 gem "matrix", "~> 0.4.2"
+
+gem "debug", "~> 1.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     json (2.10.1)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
+    matrix (0.4.2)
     minitest (5.25.4)
     parallel (1.26.3)
     parser (3.3.7.1)
@@ -56,6 +57,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  matrix (~> 0.4.2)
   minitest (~> 5.16)
   rake (~> 13.0)
   standard (~> 1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,15 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    date (3.4.1)
+    debug (1.10.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.10.1)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
@@ -16,10 +25,20 @@ GEM
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.12.0)
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rubocop (1.71.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -48,6 +67,7 @@ GEM
     standard-performance (1.6.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.23.0)
+    stringio (3.1.5)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -57,6 +77,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  debug (~> 1.10)
   matrix (~> 0.4.2)
   minitest (~> 5.16)
   rake (~> 13.0)

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -118,6 +118,14 @@ module Temporal
       end
     end
 
+    def negated
+      Duration.new(*fields.map(&:-@))
+    end
+
+    def -@ = negated
+
+    def +@ = Duration.new(*fields)
+
     private
 
     def check_sign!(args)

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -83,6 +83,10 @@ module Temporal
       sign == 0
     end
 
+    def abs
+      Duration.new(*fields.map(&:abs))
+    end
+
     private
 
     def fields

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -49,9 +49,7 @@ module Temporal
         raise RangeError.new("Arguments must be integers")
       end
 
-      unless args.all? { _1 >= 0 } || args.all? { _1 <= 0 }
-        raise RangeError.new("Mixed-sign values not allowed as duration fields")
-      end
+      check_sign! args
 
       calendar_args = [years, months, weeks]
       unless calendar_args.all? { _1 < 2**32 }
@@ -75,6 +73,28 @@ module Temporal
       @milliseconds = milliseconds
       @microseconds = microseconds
       @nanoseconds = nanoseconds
+    end
+
+    def sign
+      check_sign!(fields)
+    end
+
+    private
+
+    def fields
+      [years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds]
+    end
+
+    def check_sign!(args)
+      if args.all? { _1 == 0 }
+        0
+      elsif args.all? { _1 >= 0 }
+        1
+      elsif args.all? { _1 <= 0 }
+        -1
+      else
+        raise RangeError.new("Mixed-sign values not allowed as duration fields")
+      end
     end
   end
 end

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -4,7 +4,8 @@ require "matrix"
 
 module Temporal
   class Duration
-    attr_reader :years, :months, :weeks, :days, :hours, :minutes, :seconds, :milliseconds, :microseconds, :nanoseconds
+    FIELDS = %i[years months weeks days hours minutes seconds milliseconds microseconds nanoseconds]
+    attr_reader(*FIELDS)
 
     class << self
       def from(arg)
@@ -159,6 +160,25 @@ module Temporal
     end
 
     def to_json = to_s
+
+    def with(arg)
+      unless (arg.keys - FIELDS).empty?
+        raise ArgumentError.new("Unrecognised attributes: #{(arg.keys - FIELDS).join(", ")}")
+      end
+
+      Duration.new(
+        arg[:years] || years,
+        arg[:months] || months,
+        arg[:weeks] || weeks,
+        arg[:days] || days,
+        arg[:hours] || hours,
+        arg[:minutes] || minutes,
+        arg[:seconds] || seconds,
+        arg[:milliseconds] || milliseconds,
+        arg[:microseconds] || microseconds,
+        arg[:nanoseconds] || nanoseconds
+      )
+    end
 
     private
 

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -36,7 +36,12 @@ module Temporal
             arg[:nanoseconds] || 0
           )
         when String
-          Duration.from(ISO8601Duration.new(arg).to_h)
+          iso8601 = ISO8601Duration.new(arg).to_h
+          sign = iso8601.delete(:sign)
+          duration_values = iso8601.transform_values do |val|
+            val.nil? ? nil : val * sign
+          end
+          Duration.from(duration_values)
         else
           raise ArgumentError.new("Argument must be a Duration, Hash or String")
         end
@@ -136,6 +141,24 @@ module Temporal
     end
 
     def -(other) = subtract(other)
+
+    def to_s
+      ISO8601Duration.new(
+        sign: (sign == -1) ? -1 : 1,
+        years: years.abs,
+        months: months.abs,
+        weeks: weeks.abs,
+        days: days.abs,
+        hours: hours.abs,
+        minutes: minutes.abs,
+        seconds: seconds.abs,
+        milliseconds: milliseconds.abs,
+        microseconds: microseconds.abs,
+        nanoseconds: nanoseconds.abs
+      ).to_s
+    end
+
+    def to_json = to_s
 
     private
 

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -6,6 +6,43 @@ module Temporal
   class Duration
     attr_reader :years, :months, :weeks, :days, :hours, :minutes, :seconds, :milliseconds, :microseconds, :nanoseconds
 
+    class << self
+      def from(arg)
+        case arg
+        when Duration
+          Duration.new(
+            arg.years,
+            arg.months,
+            arg.weeks,
+            arg.days,
+            arg.hours,
+            arg.minutes,
+            arg.seconds,
+            arg.milliseconds,
+            arg.microseconds,
+            arg.nanoseconds
+          )
+        when Hash
+          Duration.new(
+            arg[:years] || 0,
+            arg[:months] || 0,
+            arg[:weeks] || 0,
+            arg[:days] || 0,
+            arg[:hours] || 0,
+            arg[:minutes] || 0,
+            arg[:seconds] || 0,
+            arg[:milliseconds] || 0,
+            arg[:microseconds] || 0,
+            arg[:nanoseconds] || 0
+          )
+        when String
+          Duration.from(ISO8601Duration.new(arg).to_h)
+        else
+          raise ArgumentError.new("Argument must be a Duration, Hash or String")
+        end
+      end
+    end
+
     def initialize(years = 0, months = 0, weeks = 0, days = 0, hours = 0, minutes = 0, seconds = 0, milliseconds = 0, microseconds = 0, nanoseconds = 0)
       args = [years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds]
       unless args.all? { _1.is_a? Integer }

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -45,10 +45,15 @@ module Temporal
       private
 
       def from_nanoseconds(nanoseconds)
+        magnitude, sign = if nanoseconds.negative?
+          [nanoseconds.abs, -1]
+        else
+          [nanoseconds, 1]
+        end
         non_calendar_totals = [24 * 60 * 60 * 1e9, 60 * 60 * 1e9, 60 * 1e9, 1e9, 1e6, 1e3, 1]
         non_calendar_values = non_calendar_totals.map do |total|
-          value, nanoseconds = nanoseconds.divmod(total)
-          value
+          value, magnitude = magnitude.divmod(total)
+          sign * value
         end
         Duration.new(0, 0, 0, *non_calendar_values)
       end
@@ -125,6 +130,12 @@ module Temporal
     def -@ = negated
 
     def +@ = Duration.new(*fields)
+
+    def subtract(other)
+      add(other.negated)
+    end
+
+    def -(other) = subtract(other)
 
     private
 

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -41,6 +41,17 @@ module Temporal
           raise ArgumentError.new("Argument must be a Duration, Hash or String")
         end
       end
+
+      private
+
+      def from_nanoseconds(nanoseconds)
+        non_calendar_totals = [24 * 60 * 60 * 1e9, 60 * 60 * 1e9, 60 * 1e9, 1e9, 1e6, 1e3, 1]
+        non_calendar_values = non_calendar_totals.map do |total|
+          value, nanoseconds = nanoseconds.divmod(total)
+          value
+        end
+        Duration.new(0, 0, 0, *non_calendar_values)
+      end
     end
 
     def initialize(years = 0, months = 0, weeks = 0, days = 0, hours = 0, minutes = 0, seconds = 0, milliseconds = 0, microseconds = 0, nanoseconds = 0)
@@ -87,6 +98,15 @@ module Temporal
       Duration.new(*fields.map(&:abs))
     end
 
+    def add(other)
+      if calendar? || other.calendar?
+        raise RangeError.new("For years, months, or weeks arithmetic, use date arithmetic relative to a starting point")
+      else
+        Duration.send(:from_nanoseconds, (total_nanoseconds + other.total_nanoseconds))
+      end
+    end
+
+    def +(other) = add(other)
 
     def ==(other)
       if fields == other.fields

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "matrix"
+
+module Temporal
+  class Duration
+    attr_reader :years, :months, :weeks, :days, :hours, :minutes, :seconds, :milliseconds, :microseconds, :nanoseconds
+
+    def initialize(years = 0, months = 0, weeks = 0, days = 0, hours = 0, minutes = 0, seconds = 0, milliseconds = 0, microseconds = 0, nanoseconds = 0)
+      args = [years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds]
+      unless args.all? { _1.is_a? Integer }
+        raise RangeError.new("Arguments must be integers")
+      end
+
+      unless args.all? { _1 >= 0 } || args.all? { _1 <= 0 }
+        raise RangeError.new("Mixed-sign values not allowed as duration fields")
+      end
+
+      calendar_args = [years, months, weeks]
+      unless calendar_args.all? { _1 < 2**32 }
+        raise RangeError.new("Calendar arguments (years, months, weeks) must be < 2**32")
+      end
+
+      non_calendar_args = Vector[days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds]
+      in_seconds = Vector[24 * 60 * 60, 60 * 60, 60, 1, 1e-3, 1e-6, 1e-9]
+      non_calendar_duration = non_calendar_args.inner_product(in_seconds)
+      unless non_calendar_duration < 2**53
+        raise RangeError.new("Non-calendar duration in seconds must be < 2**53")
+      end
+
+      @years = years
+      @months = months
+      @weeks = weeks
+      @days = days
+      @hours = hours
+      @minutes = minutes
+      @seconds = seconds
+      @milliseconds = milliseconds
+      @microseconds = microseconds
+      @nanoseconds = nanoseconds
+    end
+  end
+end

--- a/lib/temporal/duration.rb
+++ b/lib/temporal/duration.rb
@@ -79,6 +79,10 @@ module Temporal
       check_sign!(fields)
     end
 
+    def blank?
+      sign == 0
+    end
+
     private
 
     def fields

--- a/lib/temporal/iso8601_duration.rb
+++ b/lib/temporal/iso8601_duration.rb
@@ -1,7 +1,19 @@
 module Temporal
   class ISO8601Duration
-    def initialize(duration_string)
-      @duration_string = duration_string
+    FIELDS = %i[sign years months weeks days hours minutes seconds milliseconds microseconds nanoseconds]
+    attr_accessor(*FIELDS)
+
+    def initialize(arg = nil)
+      case arg
+      when nil
+        initialize_to_zero
+      when String
+        initialize_from_string(arg)
+      when Hash
+        initialize_from_hash(arg)
+      else
+        raise ArgumentError.new("Must be a a string or a hash")
+      end
     end
 
     SIGN = /(?<sign>\+|-)?/
@@ -22,26 +34,85 @@ module Temporal
     ISO8601_DURATION = /^#{SIGN}#{PERIOD}#{YEARS}#{MONTHS}#{WEEKS}#{DAYS}#{TIME}$/
 
     def to_h
-      match = ISO8601_DURATION.match(@duration_string)
+      {sign:, years:, months:, weeks:, days:, hours:, minutes:, seconds:, milliseconds:, microseconds:, nanoseconds:}
+    end
+
+    def to_s
+      sign_s = (sign == -1) ? "-" : ""
+      years_s = years.nonzero? ? "#{years}Y" : ""
+      months_s = months.nonzero? ? "#{months}M" : ""
+      weeks_s = weeks.nonzero? ? "#{weeks}W" : ""
+      days_s = days.nonzero? ? "#{days}D" : ""
+      date_s = sign_s + "P" + years_s + months_s + weeks_s + days_s
+
+      time_values = [hours, minutes, seconds, milliseconds, microseconds, nanoseconds]
+      time_s = if time_values.any?(&:nonzero?)
+        hours_s = hours.nonzero? ? "#{hours}H" : ""
+        minutes_s = minutes.nonzero? ? "#{minutes}M" : ""
+
+        subsecond_values = [milliseconds, microseconds, nanoseconds]
+        seconds_s = if subsecond_values.any?(&:nonzero?)
+          seconds_bal, nanoseconds_bal = Vector[seconds, milliseconds, microseconds, nanoseconds]
+            .inner_product(Vector[10**9, 10**6, 10**3, 1])
+            .divmod(10**9)
+          seconds_bal.to_s + "." + nanoseconds_bal.to_s.gsub(/0+$/, "") + "S"
+        else
+          seconds.nonzero? ? "#{seconds}S" : ""
+        end
+
+        "T" + hours_s + minutes_s + seconds_s
+      else
+        ""
+      end
+
+      date_s + time_s
+    end
+
+    private
+
+    def initialize_from_string(duration_string)
+      match = ISO8601_DURATION.match(duration_string)
       if match.nil?
         raise RangeError.new("Invalid duration: #{@duration_string}")
       else
-        captures = match.named_captures.reject { |k, v| k == "sign" || v.nil? || v == "" }
-        sign = (match["sign"] == "-") ? -1 : 1
+        captures = match.named_captures.reject { |k, v| v.nil? || v == "" }
+        self.sign = (captures.delete("sign") == "-") ? -1 : 1
 
         unless captures.count > 0
           raise RangeError.new("Invalid duration: #{@duration_string}")
         end
 
-        captures.map do |key, value|
-          if %w[years months weeks days hours minutes seconds].include?(key)
-            [key.to_sym, sign * value.to_i]
+        captures.each do |key, value|
+          parsed_value = if %w[years months weeks days hours minutes seconds].include?(key)
+            value.to_i
           elsif %w[milliseconds microseconds nanoseconds].include?(key)
-            [key.to_sym, sign * value.ljust(3, "0").to_i]
+            value.ljust(3, "0").to_i
           else
             raise "Internal error: unrecognised named capture."
           end
-        end.to_h
+
+          public_send :"#{key}=", parsed_value
+        end
+      end
+    end
+
+    def initialize_to_zero
+      FIELDS.each { |field| public_send(:"#{field}=", 0) }
+      self.sign = 1
+    end
+
+    def initialize_from_hash(arg)
+      unless (arg.keys - FIELDS).empty?
+        raise ArgumentError.new("Unrecognised attributes: #{(arg.keys - FIELDS).join(", ")}")
+      end
+
+      FIELDS.each do |field|
+        value = if field == :sign
+          arg[field] || 1
+        else
+          arg[field] || 0
+        end
+        public_send(:"#{field}=", value)
       end
     end
   end

--- a/lib/temporal/iso8601_duration.rb
+++ b/lib/temporal/iso8601_duration.rb
@@ -1,0 +1,48 @@
+module Temporal
+  class ISO8601Duration
+    def initialize(duration_string)
+      @duration_string = duration_string
+    end
+
+    SIGN = /(?<sign>\+|-)?/
+    PERIOD = /[pP]/
+    YEARS = /(?:(?<years>\d+)Y|)/
+    MONTHS = /(?:(?<months>\d+)M|)/
+    WEEKS = /(?:(?<weeks>\d+)W|)/
+    DAYS = /(?:(?<days>\d+)D|)/
+
+    HOURS = /(?:(?<hours>\d+)H|)/
+    MINUTES = /(?:(?<minutes>\d+)M|)/
+    MILLISECONDS = /(?<milliseconds>\d{1,3})/
+    MICROSECONDS = /(?<microseconds>\d{0,3})/
+    NANOSECONDS = /(?<nanoseconds>\d{0,3})/
+    SECONDS = /(?:(?<seconds>\d+)(?:\.#{MILLISECONDS}#{MICROSECONDS}#{NANOSECONDS})?S|)/
+    TIME = /(?:T(?=.)#{HOURS}#{MINUTES}#{SECONDS}|)/
+
+    ISO8601_DURATION = /^#{SIGN}#{PERIOD}#{YEARS}#{MONTHS}#{WEEKS}#{DAYS}#{TIME}$/
+
+    def to_h
+      match = ISO8601_DURATION.match(@duration_string)
+      if match.nil?
+        raise RangeError.new("Invalid duration: #{@duration_string}")
+      else
+        captures = match.named_captures.reject { |k, v| k == "sign" || v.nil? || v == "" }
+        sign = (match["sign"] == "-") ? -1 : 1
+
+        unless captures.count > 0
+          raise RangeError.new("Invalid duration: #{@duration_string}")
+        end
+
+        captures.map do |key, value|
+          if %w[years months weeks days hours minutes seconds].include?(key)
+            [key.to_sym, sign * value.to_i]
+          elsif %w[milliseconds microseconds nanoseconds].include?(key)
+            [key.to_sym, sign * value.ljust(3, "0").to_i]
+          else
+            raise "Internal error: unrecognised named capture."
+          end
+        end.to_h
+      end
+    end
+  end
+end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -179,5 +179,13 @@ module Temporal
       duration = Duration.new
       assert_equal 0, duration.sign
     end
+
+    def test_blank
+      duration = Duration.new(1)
+      assert_equal false, duration.blank?
+
+      duration = Duration.new
+      assert_equal true, duration.blank?
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -288,5 +288,24 @@ module Temporal
 
       assert_equal Duration.from("P1D"), Duration.from("P3D") - Duration.from("P2D")
     end
+
+    def test_to_s
+      duration = Duration.from("P1Y1M1W1DT1H1M1.111111111S")
+      assert_equal "P1Y1M1W1DT1H1M1.111111111S", duration.to_s
+
+      duration = Duration.from("-P1Y1M1W1DT1H1M1.111111111S")
+      assert_equal "-P1Y1M1W1DT1H1M1.111111111S", duration.to_s
+
+      duration = Duration.from("+P1Y1M1W1DT1H1M1.111111111S")
+      assert_equal "P1Y1M1W1DT1H1M1.111111111S", duration.to_s
+
+      duration = Duration.from("P123Y456M789W987DT654H321M234.567898765S")
+      assert_equal "P123Y456M789W987DT654H321M234.567898765S", duration.to_s
+    end
+
+    def test_to_json
+      duration = Duration.from("P1Y1M1W1DT1H1M1.111111111S")
+      assert_equal "P1Y1M1W1DT1H1M1.111111111S", duration.to_json
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -244,5 +244,22 @@ module Temporal
 
       assert_equal Duration.from("P3D"), Duration.from("P1D") + Duration.from("P2D")
     end
+
+    def test_negated
+      all_ones = Duration.new(1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+      all_zeros = Duration.new
+      all_minus_ones = Duration.new(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
+
+      assert_equal all_ones, all_minus_ones.negated
+      assert_equal all_minus_ones, all_ones.negated
+      assert_equal all_zeros, all_zeros.negated
+
+      assert_equal all_ones.negated, -all_ones
+    end
+
+    def test_identity
+      duration = Duration.from("P1Y1M1W1DT1H1M1S")
+      assert_equal duration, +duration
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -218,5 +218,31 @@ module Temporal
       assert_equal Duration.from("PT1H"), Duration.from("PT60M")
       assert_equal Duration.from("PT1M"), Duration.from("PT60S")
     end
+
+    def test_add
+      calendar_cases = [
+        [1],
+        [0, 1],
+        [0, 0, 1]
+      ]
+      non_calendar_case = [0, 0, 0, 1]
+      calendar_cases.each do |calendar_case|
+        assert_raises RangeError do
+          duration_to_add = Duration.new(*non_calendar_case)
+          Duration.new(*calendar_case).add(duration_to_add)
+        end
+
+        assert_raises RangeError do
+          duration_to_add = Duration.new(*calendar_case)
+          Duration.new(*non_calendar_case).add(duration_to_add)
+        end
+      end
+
+      assert_equal Duration.from("P3D"), Duration.from("P1D").add(Duration.from("P2D"))
+      assert_equal Duration.from("P1DT4H"), Duration.from("PT20H").add(Duration.from("PT8H"))
+      assert_equal Duration.from("P1DT4H"), Duration.from("PT20H").add(Duration.from("PT6H60M3600S"))
+
+      assert_equal Duration.from("P3D"), Duration.from("P1D") + Duration.from("P2D")
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "temporal/duration"
+
+module Temporal
+  class DurationTest < Minitest::Test
+    def test_initialize
+      duration = Duration.new
+      assert_equal 0, duration.years
+
+      duration = Duration.new(10)
+      assert_equal 10, duration.years
+      assert_equal 0, duration.months
+
+      duration = Duration.new(10, 8)
+      assert_equal 8, duration.months
+      assert_equal 0, duration.weeks
+
+      duration = Duration.new(10, 8, 6)
+      assert_equal 6, duration.weeks
+      assert_equal 0, duration.days
+
+      duration = Duration.new(10, 8, 6, 4)
+      assert_equal 4, duration.days
+      assert_equal 0, duration.hours
+
+      duration = Duration.new(10, 8, 6, 4, 2)
+      assert_equal 2, duration.hours
+      assert_equal 0, duration.minutes
+
+      duration = Duration.new(10, 8, 6, 4, 2, 1)
+      assert_equal 1, duration.minutes
+      assert_equal 0, duration.seconds
+
+      duration = Duration.new(10, 8, 6, 4, 2, 1, 3)
+      assert_equal 3, duration.seconds
+      assert_equal 0, duration.milliseconds
+
+      duration = Duration.new(10, 8, 6, 4, 2, 1, 3, 5)
+      assert_equal 5, duration.milliseconds
+      assert_equal 0, duration.microseconds
+
+      duration = Duration.new(10, 8, 6, 4, 2, 1, 3, 5, 7)
+      assert_equal 7, duration.microseconds
+      assert_equal 0, duration.nanoseconds
+
+      duration = Duration.new(10, 8, 6, 4, 2, 1, 3, 5, 7, 9)
+      assert_equal 7, duration.microseconds
+      assert_equal 9, duration.nanoseconds
+    end
+
+    def test_intialize_with_non_integer_argument
+      cases = [
+        [0.1],
+        [0, 0.1],
+        [0, 0, 0.1],
+        [0, 0, 0, 0.1],
+        [0, 0, 0, 0, 0.1],
+        [0, 0, 0, 0, 0, 0.1],
+        [0, 0, 0, 0, 0, 0, 0.1],
+        [0, 0, 0, 0, 0, 0, 0, 0.1],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0.1],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1]
+      ]
+      cases.each do |args|
+        assert_raises RangeError do
+          Duration.new(*args)
+        end
+      end
+    end
+
+    def test_initialize_with_oversized_calendar_argument
+      cases = [
+        [2**32],
+        [0, 2**32],
+        [0, 0, 2**32]
+      ]
+      cases.each do |args|
+        assert_raises RangeError do
+          Duration.new(*args)
+        end
+      end
+    end
+
+    def test_initialize_with_oversized_non_calendar_argument
+      day = 24 * 60 * 60
+      cases = [
+        [0, 0, 0, 2**53 / day + 1],
+        [0, 0, 0, 0, 0, 0, 2**53],
+        [0, 0, 0, 0, 0, 0, 0, 2**53 * 1e3]
+      ]
+      cases.each do |args|
+        assert_raises RangeError do
+          Duration.new(*args)
+        end
+      end
+    end
+
+    def test_initialize_with_mixed_signs
+      assert_raises RangeError do
+        Duration.new(1, 0, -1, 0, 4, 0, -3, 0, 2, 0)
+      end
+    end
+  end
+end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -101,5 +101,66 @@ module Temporal
         Duration.new(1, 0, -1, 0, 4, 0, -3, 0, 2, 0)
       end
     end
+
+    def test_from_duration
+      duration = Duration.from(
+        Duration.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      )
+      assert_equal 1, duration.years
+      assert_equal 2, duration.months
+      assert_equal 3, duration.weeks
+      assert_equal 4, duration.days
+      assert_equal 5, duration.hours
+      assert_equal 6, duration.minutes
+      assert_equal 7, duration.seconds
+      assert_equal 8, duration.milliseconds
+      assert_equal 9, duration.microseconds
+      assert_equal 10, duration.nanoseconds
+    end
+
+    def test_from_hash
+      duration = Duration.from(
+        years: 1,
+        months: 2,
+        weeks: 3,
+        days: 4,
+        hours: 5,
+        minutes: 6,
+        seconds: 7,
+        milliseconds: 8,
+        microseconds: 9,
+        nanoseconds: 10
+      )
+      assert_equal 1, duration.years
+      assert_equal 2, duration.months
+      assert_equal 3, duration.weeks
+      assert_equal 4, duration.days
+      assert_equal 5, duration.hours
+      assert_equal 6, duration.minutes
+      assert_equal 7, duration.seconds
+      assert_equal 8, duration.milliseconds
+      assert_equal 9, duration.microseconds
+      assert_equal 10, duration.nanoseconds
+    end
+
+    def test_from_invalid
+      assert_raises ArgumentError do
+        Duration.from(Object.new)
+      end
+    end
+
+    def test_from_iso8601_duration
+      duration = Duration.from("P1Y2M40W4DT5H6M678.008009010S")
+      assert_equal 1, duration.years
+      assert_equal 2, duration.months
+      assert_equal 40, duration.weeks
+      assert_equal 4, duration.days
+      assert_equal 5, duration.hours
+      assert_equal 6, duration.minutes
+      assert_equal 678, duration.seconds
+      assert_equal 8, duration.milliseconds
+      assert_equal 9, duration.microseconds
+      assert_equal 10, duration.nanoseconds
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -261,5 +261,32 @@ module Temporal
       duration = Duration.from("P1Y1M1W1DT1H1M1S")
       assert_equal duration, +duration
     end
+
+    def test_subtract
+      calendar_cases = [
+        [1],
+        [0, 1],
+        [0, 0, 1]
+      ]
+      non_calendar_case = [0, 0, 0, 1]
+      calendar_cases.each do |calendar_case|
+        assert_raises RangeError do
+          duration_to_subtract = Duration.new(*non_calendar_case)
+          Duration.new(*calendar_case).subtract(duration_to_subtract)
+        end
+
+        assert_raises RangeError do
+          duration_to_subtract = Duration.new(*calendar_case)
+          Duration.new(*non_calendar_case).subtract(duration_to_subtract)
+        end
+      end
+
+      assert_equal Duration.from("P3D"), Duration.from("P4D").subtract(Duration.from("P1D"))
+      assert_equal Duration.from("PT20H"), Duration.from("P1DT4H").subtract(Duration.from("PT8H"))
+      assert_equal Duration.from("PT20H"), Duration.from("P1DT4H").subtract(Duration.from("PT6H60M3600S"))
+      assert_equal Duration.from("-PT15M"), Duration.from("P1D").subtract(Duration.from("PT24H15M"))
+
+      assert_equal Duration.from("P1D"), Duration.from("P3D") - Duration.from("P2D")
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -307,5 +307,57 @@ module Temporal
       duration = Duration.from("P1Y1M1W1DT1H1M1.111111111S")
       assert_equal "P1Y1M1W1DT1H1M1.111111111S", duration.to_json
     end
+
+    def test_with
+      assert_raises ArgumentError do
+        Duration.new.with(foo: "foo")
+      end
+
+      original_duration = Duration.new
+      new_duration = original_duration.with(
+        years: 1,
+        months: 2,
+        weeks: 3,
+        days: 4,
+        hours: 5,
+        minutes: 6,
+        seconds: 7,
+        milliseconds: 8,
+        microseconds: 9,
+        nanoseconds: 10
+      )
+      assert_equal Duration.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), new_duration
+
+      original_duration = Duration.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      new_duration = original_duration.with({})
+      assert_equal Duration.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), new_duration
+
+      original_duration = Duration.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      new_duration = original_duration.with(
+        years: 11,
+        months: 12,
+        weeks: 13,
+        days: 14,
+        hours: 15,
+        minutes: 16,
+        seconds: 17,
+        milliseconds: 18,
+        microseconds: 19,
+        nanoseconds: 20
+      )
+      assert_equal Duration.new(11, 12, 13, 14, 15, 16, 17, 18, 19, 20), new_duration
+
+      original_duration = Duration.new(1, 2, 3, 4, 5, 6, 7)
+      new_duration = original_duration.with(
+        days: 14,
+        hours: 15,
+        minutes: 16,
+        seconds: 17,
+        milliseconds: 18,
+        microseconds: 19,
+        nanoseconds: 20
+      )
+      assert_equal Duration.new(1, 2, 3, 14, 15, 16, 17, 18, 19, 20), new_duration
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -204,5 +204,19 @@ module Temporal
         assert_equal 0, duration.public_send(unit)
       end
     end
+
+    def test_equal
+      assert_raises RangeError do
+        Duration.from("P1Y") == Duration.new(0, 12)
+      end
+
+      assert_equal Duration.from("P1D"), Duration.new(0, 0, 0, 1)
+      refute_equal Duration.from("P1D"), Duration.new(0, 0, 0, 2)
+      assert_equal Duration.from("P1Y"), Duration.new(1)
+
+      assert_equal Duration.from("P1D"), Duration.from("PT24H")
+      assert_equal Duration.from("PT1H"), Duration.from("PT60M")
+      assert_equal Duration.from("PT1M"), Duration.from("PT60S")
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -187,5 +187,22 @@ module Temporal
       duration = Duration.new
       assert_equal true, duration.blank?
     end
+
+    def test_abs
+      duration = Duration.new(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1).abs
+      %i[years months weeks days hours minutes seconds milliseconds microseconds nanoseconds].each do |unit|
+        assert_equal 1, duration.public_send(unit)
+      end
+
+      duration = Duration.new(1, 1, 1, 1, 1, 1, 1, 1, 1, 1).abs
+      %i[years months weeks days hours minutes seconds milliseconds microseconds nanoseconds].each do |unit|
+        assert_equal 1, duration.public_send(unit)
+      end
+
+      duration = Duration.new.abs
+      %i[years months weeks days hours minutes seconds milliseconds microseconds nanoseconds].each do |unit|
+        assert_equal 0, duration.public_send(unit)
+      end
+    end
   end
 end

--- a/test/temporal/test_duration.rb
+++ b/test/temporal/test_duration.rb
@@ -162,5 +162,22 @@ module Temporal
       assert_equal 9, duration.microseconds
       assert_equal 10, duration.nanoseconds
     end
+
+    def test_sign
+      duration = Duration.new(1)
+      assert_equal 1, duration.sign
+
+      duration = Duration.new(1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+      assert_equal 1, duration.sign
+
+      duration = Duration.new(-1)
+      assert_equal(-1, duration.sign)
+
+      duration = Duration.new(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
+      assert_equal(-1, duration.sign)
+
+      duration = Duration.new
+      assert_equal 0, duration.sign
+    end
   end
 end

--- a/test/temporal/test_iso8601_duration.rb
+++ b/test/temporal/test_iso8601_duration.rb
@@ -177,6 +177,18 @@ module Temporal
       assert_equal 8, duration[:milliseconds]
       assert_equal 9, duration[:microseconds]
       assert_equal 10, duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("-P1Y2M3W4DT5H6M7.008009010S").to_h
+      assert_equal(-1, duration[:years])
+      assert_equal(-2, duration[:months])
+      assert_equal(-3, duration[:weeks])
+      assert_equal(-4, duration[:days])
+      assert_equal(-5, duration[:hours])
+      assert_equal(-6, duration[:minutes])
+      assert_equal(-7, duration[:seconds])
+      assert_equal(-8, duration[:milliseconds])
+      assert_equal(-9, duration[:microseconds])
+      assert_equal(-10, duration[:nanoseconds])
     end
   end
 end

--- a/test/temporal/test_iso8601_duration.rb
+++ b/test/temporal/test_iso8601_duration.rb
@@ -1,10 +1,33 @@
 # frozen_string_literal: true
 
 require "temporal/iso8601_duration"
+require "debug"
 
 module Temporal
   class ISO8601DurationTest < Minitest::Test
-    def test_to_h
+    # TODO Sign should be returned separately, not applied to values. That can be done in Duration.
+    def test_initialize_invalid
+      assert_raises ArgumentError do
+        ISO8601Duration.new(Object.new)
+      end
+    end
+
+    def test_initialize_to_zero
+      duration = ISO8601Duration.new
+      assert_equal 1, duration.sign
+      assert_equal 0, duration.years
+      assert_equal 0, duration.months
+      assert_equal 0, duration.weeks
+      assert_equal 0, duration.days
+      assert_equal 0, duration.hours
+      assert_equal 0, duration.minutes
+      assert_equal 0, duration.seconds
+      assert_equal 0, duration.milliseconds
+      assert_equal 0, duration.microseconds
+      assert_equal 0, duration.nanoseconds
+    end
+
+    def test_initialize_with_string
       invalid_cases = [
         "",
         "+",
@@ -29,166 +52,258 @@ module Temporal
       ]
       invalid_cases.each do |test_case|
         assert_raises RangeError, "Duration string #{test_case} should raise a RangeError" do
-          ISO8601Duration.new(test_case).to_h
+          ISO8601Duration.new(test_case)
         end
       end
 
-      duration = ISO8601Duration.new("P12Y").to_h
-      assert_equal 12, duration[:years]
-      assert_nil duration[:months]
+      duration = ISO8601Duration.new("P12Y")
+      assert_equal 1, duration.sign
+      assert_equal 12, duration.years
+      assert_nil duration.months
 
-      duration = ISO8601Duration.new("+P1Y").to_h
-      assert_equal 1, duration[:years]
-      assert_nil duration[:months]
+      duration = ISO8601Duration.new("+P1Y")
+      assert_equal 1, duration.sign
+      assert_equal 1, duration.years
+      assert_nil duration.months
 
-      duration = ISO8601Duration.new("-P1Y").to_h
-      assert_equal(-1, duration[:years])
-      assert_nil duration[:months]
+      duration = ISO8601Duration.new("-P1Y")
+      assert_equal(-1, duration.sign)
+      assert_equal 1, duration.years
+      assert_nil duration.months
 
-      duration = ISO8601Duration.new("P12M").to_h
-      assert_nil duration[:years]
-      assert_equal 12, duration[:months]
-      assert_nil duration[:weeks]
+      duration = ISO8601Duration.new("P12M")
+      assert_nil duration.years
+      assert_equal 12, duration.months
+      assert_nil duration.weeks
 
-      duration = ISO8601Duration.new("P2Y1M").to_h
-      assert_equal 2, duration[:years]
-      assert_equal 1, duration[:months]
+      duration = ISO8601Duration.new("P2Y1M")
+      assert_equal 2, duration.years
+      assert_equal 1, duration.months
 
-      duration = ISO8601Duration.new("P12W").to_h
-      assert_nil duration[:months]
-      assert_equal 12, duration[:weeks]
-      assert_nil duration[:days]
+      duration = ISO8601Duration.new("P12W")
+      assert_nil duration.months
+      assert_equal 12, duration.weeks
+      assert_nil duration.days
 
-      duration = ISO8601Duration.new("P2M1W").to_h
-      assert_equal 2, duration[:months]
-      assert_equal 1, duration[:weeks]
+      duration = ISO8601Duration.new("P2M1W")
+      assert_equal 2, duration.months
+      assert_equal 1, duration.weeks
 
-      duration = ISO8601Duration.new("P3Y2M1W").to_h
-      assert_equal 3, duration[:years]
-      assert_equal 2, duration[:months]
-      assert_equal 1, duration[:weeks]
+      duration = ISO8601Duration.new("P3Y2M1W")
+      assert_equal 3, duration.years
+      assert_equal 2, duration.months
+      assert_equal 1, duration.weeks
 
-      duration = ISO8601Duration.new("P12D").to_h
-      assert_nil duration[:weeks]
-      assert_equal 12, duration[:days]
-      assert_nil duration[:seconds]
+      duration = ISO8601Duration.new("P12D")
+      assert_nil duration.weeks
+      assert_equal 12, duration.days
+      assert_nil duration.seconds
 
-      duration = ISO8601Duration.new("P2W1D").to_h
-      assert_equal 2, duration[:weeks]
-      assert_equal 1, duration[:days]
+      duration = ISO8601Duration.new("P2W1D")
+      assert_equal 2, duration.weeks
+      assert_equal 1, duration.days
 
-      duration = ISO8601Duration.new("P3M2W1D").to_h
-      assert_equal 3, duration[:months]
-      assert_equal 2, duration[:weeks]
-      assert_equal 1, duration[:days]
+      duration = ISO8601Duration.new("P3M2W1D")
+      assert_equal 3, duration.months
+      assert_equal 2, duration.weeks
+      assert_equal 1, duration.days
 
-      duration = ISO8601Duration.new("PT12H").to_h
-      assert_nil duration[:days]
-      assert_equal 12, duration[:hours]
-      assert_nil duration[:minutes]
+      duration = ISO8601Duration.new("PT12H")
+      assert_nil duration.days
+      assert_equal 12, duration.hours
+      assert_nil duration.minutes
 
-      duration = ISO8601Duration.new("P2DT1H").to_h
-      assert_equal 2, duration[:days]
-      assert_equal 1, duration[:hours]
+      duration = ISO8601Duration.new("P2DT1H")
+      assert_equal 2, duration.days
+      assert_equal 1, duration.hours
 
-      duration = ISO8601Duration.new("PT12M").to_h
-      assert_nil duration[:months]
-      assert_nil duration[:hours]
-      assert_equal 12, duration[:minutes]
-      assert_nil duration[:seconds]
+      duration = ISO8601Duration.new("PT12M")
+      assert_nil duration.months
+      assert_nil duration.hours
+      assert_equal 12, duration.minutes
+      assert_nil duration.seconds
 
-      duration = ISO8601Duration.new("P2MT1M").to_h
-      assert_equal 2, duration[:months]
-      assert_equal 1, duration[:minutes]
+      duration = ISO8601Duration.new("P2MT1M")
+      assert_equal 2, duration.months
+      assert_equal 1, duration.minutes
 
-      duration = ISO8601Duration.new("PT12S").to_h
-      assert_nil duration[:minutes]
-      assert_equal 12, duration[:seconds]
-      assert_nil duration[:milliseconds]
+      duration = ISO8601Duration.new("PT12S")
+      assert_nil duration.minutes
+      assert_equal 12, duration.seconds
+      assert_nil duration.milliseconds
 
-      duration = ISO8601Duration.new("PT1.2S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 200, duration[:milliseconds]
-      assert_nil duration[:microseconds]
-      assert_nil duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.2S")
+      assert_equal 1, duration.seconds
+      assert_equal 200, duration.milliseconds
+      assert_nil duration.microseconds
+      assert_nil duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.23S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 230, duration[:milliseconds]
-      assert_nil duration[:microseconds]
-      assert_nil duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.23S")
+      assert_equal 1, duration.seconds
+      assert_equal 230, duration.milliseconds
+      assert_nil duration.microseconds
+      assert_nil duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.234S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 234, duration[:milliseconds]
-      assert_nil duration[:microseconds]
-      assert_nil duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.234S")
+      assert_equal 1, duration.seconds
+      assert_equal 234, duration.milliseconds
+      assert_nil duration.microseconds
+      assert_nil duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.2345S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 234, duration[:milliseconds]
-      assert_equal 500, duration[:microseconds]
-      assert_nil duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.2345S")
+      assert_equal 1, duration.seconds
+      assert_equal 234, duration.milliseconds
+      assert_equal 500, duration.microseconds
+      assert_nil duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.23456S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 234, duration[:milliseconds]
-      assert_equal 560, duration[:microseconds]
-      assert_nil duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.23456S")
+      assert_equal 1, duration.seconds
+      assert_equal 234, duration.milliseconds
+      assert_equal 560, duration.microseconds
+      assert_nil duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.234567S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 234, duration[:milliseconds]
-      assert_equal 567, duration[:microseconds]
-      assert_nil duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.234567S")
+      assert_equal 1, duration.seconds
+      assert_equal 234, duration.milliseconds
+      assert_equal 567, duration.microseconds
+      assert_nil duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.000000000S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 0, duration[:milliseconds]
-      assert_equal 0, duration[:microseconds]
-      assert_equal 0, duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.000000000S")
+      assert_equal 1, duration.seconds
+      assert_equal 0, duration.milliseconds
+      assert_equal 0, duration.microseconds
+      assert_equal 0, duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.2345678S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 234, duration[:milliseconds]
-      assert_equal 567, duration[:microseconds]
-      assert_equal 800, duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.2345678S")
+      assert_equal 1, duration.seconds
+      assert_equal 234, duration.milliseconds
+      assert_equal 567, duration.microseconds
+      assert_equal 800, duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.23456789S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 234, duration[:milliseconds]
-      assert_equal 567, duration[:microseconds]
-      assert_equal 890, duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.23456789S")
+      assert_equal 1, duration.seconds
+      assert_equal 234, duration.milliseconds
+      assert_equal 567, duration.microseconds
+      assert_equal 890, duration.nanoseconds
 
-      duration = ISO8601Duration.new("PT1.234567898S").to_h
-      assert_equal 1, duration[:seconds]
-      assert_equal 234, duration[:milliseconds]
-      assert_equal 567, duration[:microseconds]
-      assert_equal 898, duration[:nanoseconds]
+      duration = ISO8601Duration.new("PT1.234567898S")
+      assert_equal 1, duration.seconds
+      assert_equal 234, duration.milliseconds
+      assert_equal 567, duration.microseconds
+      assert_equal 898, duration.nanoseconds
 
-      duration = ISO8601Duration.new("P1Y2M3W4DT5H6M7.008009010S").to_h
-      assert_equal 1, duration[:years]
-      assert_equal 2, duration[:months]
-      assert_equal 3, duration[:weeks]
-      assert_equal 4, duration[:days]
-      assert_equal 5, duration[:hours]
-      assert_equal 6, duration[:minutes]
-      assert_equal 7, duration[:seconds]
-      assert_equal 8, duration[:milliseconds]
-      assert_equal 9, duration[:microseconds]
-      assert_equal 10, duration[:nanoseconds]
+      duration = ISO8601Duration.new("P1Y2M3W4DT5H6M7.008009010S")
+      assert_equal 1, duration.years
+      assert_equal 2, duration.months
+      assert_equal 3, duration.weeks
+      assert_equal 4, duration.days
+      assert_equal 5, duration.hours
+      assert_equal 6, duration.minutes
+      assert_equal 7, duration.seconds
+      assert_equal 8, duration.milliseconds
+      assert_equal 9, duration.microseconds
+      assert_equal 10, duration.nanoseconds
 
-      duration = ISO8601Duration.new("-P1Y2M3W4DT5H6M7.008009010S").to_h
-      assert_equal(-1, duration[:years])
-      assert_equal(-2, duration[:months])
-      assert_equal(-3, duration[:weeks])
-      assert_equal(-4, duration[:days])
-      assert_equal(-5, duration[:hours])
-      assert_equal(-6, duration[:minutes])
-      assert_equal(-7, duration[:seconds])
-      assert_equal(-8, duration[:milliseconds])
-      assert_equal(-9, duration[:microseconds])
-      assert_equal(-10, duration[:nanoseconds])
+      duration = ISO8601Duration.new("-P1Y2M3W4DT5H6M7.008009010S")
+      assert_equal(-1, duration.sign)
+      assert_equal 1, duration.years
+      assert_equal 2, duration.months
+      assert_equal 3, duration.weeks
+      assert_equal 4, duration.days
+      assert_equal 5, duration.hours
+      assert_equal 6, duration.minutes
+      assert_equal 7, duration.seconds
+      assert_equal 8, duration.milliseconds
+      assert_equal 9, duration.microseconds
+      assert_equal 10, duration.nanoseconds
+    end
+
+    # TODO Test refusing mixed signs
+    def test_initialize_with_hash
+      assert_raises ArgumentError do
+        ISO8601Duration.new(foo: 1)
+      end
+
+      duration = ISO8601Duration.new({})
+      assert_equal 1, duration.sign
+      assert_equal 0, duration.years
+      assert_equal 0, duration.months
+      assert_equal 0, duration.weeks
+      assert_equal 0, duration.days
+      assert_equal 0, duration.hours
+      assert_equal 0, duration.minutes
+      assert_equal 0, duration.seconds
+      assert_equal 0, duration.milliseconds
+      assert_equal 0, duration.microseconds
+      assert_equal 0, duration.nanoseconds
+
+      duration = ISO8601Duration.new({
+        sign: -1,
+        years: 1,
+        months: 2,
+        weeks: 3,
+        days: 4,
+        hours: 5,
+        minutes: 6,
+        seconds: 7,
+        milliseconds: 8,
+        microseconds: 9,
+        nanoseconds: 10
+      })
+      assert_equal(-1, duration.sign)
+      assert_equal 1, duration.years
+      assert_equal 2, duration.months
+      assert_equal 3, duration.weeks
+      assert_equal 4, duration.days
+      assert_equal 5, duration.hours
+      assert_equal 6, duration.minutes
+      assert_equal 7, duration.seconds
+      assert_equal 8, duration.milliseconds
+      assert_equal 9, duration.microseconds
+      assert_equal 10, duration.nanoseconds
+    end
+
+    def to_h
+      duration = Duration.new
+      duration.sign = -1
+      duration.years = 1
+      duration.months = 2
+      duration.weeks = 3
+      duration.days = 4
+      duration.hours = 5
+      duration.minutes = 6
+      duration.seconds = 7
+      duration.milliseconds = 8
+      duration.microseconds = 9
+      duration.nanoseconds = 10
+
+      assert_equal({
+        sign: -1,
+        years: 1,
+        months: 2,
+        weeks: 3,
+        days: 4,
+        hours: 5,
+        minutes: 6,
+        seconds: 7,
+        milliseconds: 8,
+        microseconds: 9,
+        nanoseconds: 10
+      }, duration.to_h)
+    end
+
+    def test_to_s
+      duration = ISO8601Duration.new("P1Y1M1W1DT1H1M1.111111111S")
+      assert_equal "P1Y1M1W1DT1H1M1.111111111S", duration.to_s
+
+      duration = ISO8601Duration.new("-P1Y1M1W1DT1H1M1.111111111S")
+      assert_equal "-P1Y1M1W1DT1H1M1.111111111S", duration.to_s
+
+      duration = ISO8601Duration.new("+P1Y1M1W1DT1H1M1.111111111S")
+      assert_equal "P1Y1M1W1DT1H1M1.111111111S", duration.to_s
+
+      duration = ISO8601Duration.new("P123Y456M789W987DT654H321M234.567898765S")
+      assert_equal "P123Y456M789W987DT654H321M234.567898765S", duration.to_s
     end
   end
 end

--- a/test/temporal/test_iso8601_duration.rb
+++ b/test/temporal/test_iso8601_duration.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require "temporal/iso8601_duration"
+
+module Temporal
+  class ISO8601DurationTest < Minitest::Test
+    def test_to_h
+      invalid_cases = [
+        "",
+        "+",
+        "-",
+        "P",
+        "+P",
+        "-P",
+        "P1",
+        "PY",
+        "PM",
+        "P1YM",
+        "P1M1Y",
+        "P1Y1MW",
+        "P1Y1M1WD",
+        "PT",
+        "P1YT",
+        "PTH",
+        "PT1HM",
+        "PT1H1MS",
+        "PT1.S",
+        "PT1.0000000000S"
+      ]
+      invalid_cases.each do |test_case|
+        assert_raises RangeError, "Duration string #{test_case} should raise a RangeError" do
+          ISO8601Duration.new(test_case).to_h
+        end
+      end
+
+      duration = ISO8601Duration.new("P12Y").to_h
+      assert_equal 12, duration[:years]
+      assert_nil duration[:months]
+
+      duration = ISO8601Duration.new("+P1Y").to_h
+      assert_equal 1, duration[:years]
+      assert_nil duration[:months]
+
+      duration = ISO8601Duration.new("-P1Y").to_h
+      assert_equal(-1, duration[:years])
+      assert_nil duration[:months]
+
+      duration = ISO8601Duration.new("P12M").to_h
+      assert_nil duration[:years]
+      assert_equal 12, duration[:months]
+      assert_nil duration[:weeks]
+
+      duration = ISO8601Duration.new("P2Y1M").to_h
+      assert_equal 2, duration[:years]
+      assert_equal 1, duration[:months]
+
+      duration = ISO8601Duration.new("P12W").to_h
+      assert_nil duration[:months]
+      assert_equal 12, duration[:weeks]
+      assert_nil duration[:days]
+
+      duration = ISO8601Duration.new("P2M1W").to_h
+      assert_equal 2, duration[:months]
+      assert_equal 1, duration[:weeks]
+
+      duration = ISO8601Duration.new("P3Y2M1W").to_h
+      assert_equal 3, duration[:years]
+      assert_equal 2, duration[:months]
+      assert_equal 1, duration[:weeks]
+
+      duration = ISO8601Duration.new("P12D").to_h
+      assert_nil duration[:weeks]
+      assert_equal 12, duration[:days]
+      assert_nil duration[:seconds]
+
+      duration = ISO8601Duration.new("P2W1D").to_h
+      assert_equal 2, duration[:weeks]
+      assert_equal 1, duration[:days]
+
+      duration = ISO8601Duration.new("P3M2W1D").to_h
+      assert_equal 3, duration[:months]
+      assert_equal 2, duration[:weeks]
+      assert_equal 1, duration[:days]
+
+      duration = ISO8601Duration.new("PT12H").to_h
+      assert_nil duration[:days]
+      assert_equal 12, duration[:hours]
+      assert_nil duration[:minutes]
+
+      duration = ISO8601Duration.new("P2DT1H").to_h
+      assert_equal 2, duration[:days]
+      assert_equal 1, duration[:hours]
+
+      duration = ISO8601Duration.new("PT12M").to_h
+      assert_nil duration[:months]
+      assert_nil duration[:hours]
+      assert_equal 12, duration[:minutes]
+      assert_nil duration[:seconds]
+
+      duration = ISO8601Duration.new("P2MT1M").to_h
+      assert_equal 2, duration[:months]
+      assert_equal 1, duration[:minutes]
+
+      duration = ISO8601Duration.new("PT12S").to_h
+      assert_nil duration[:minutes]
+      assert_equal 12, duration[:seconds]
+      assert_nil duration[:milliseconds]
+
+      duration = ISO8601Duration.new("PT1.2S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 200, duration[:milliseconds]
+      assert_nil duration[:microseconds]
+      assert_nil duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.23S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 230, duration[:milliseconds]
+      assert_nil duration[:microseconds]
+      assert_nil duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.234S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 234, duration[:milliseconds]
+      assert_nil duration[:microseconds]
+      assert_nil duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.2345S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 234, duration[:milliseconds]
+      assert_equal 500, duration[:microseconds]
+      assert_nil duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.23456S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 234, duration[:milliseconds]
+      assert_equal 560, duration[:microseconds]
+      assert_nil duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.234567S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 234, duration[:milliseconds]
+      assert_equal 567, duration[:microseconds]
+      assert_nil duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.000000000S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 0, duration[:milliseconds]
+      assert_equal 0, duration[:microseconds]
+      assert_equal 0, duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.2345678S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 234, duration[:milliseconds]
+      assert_equal 567, duration[:microseconds]
+      assert_equal 800, duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.23456789S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 234, duration[:milliseconds]
+      assert_equal 567, duration[:microseconds]
+      assert_equal 890, duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("PT1.234567898S").to_h
+      assert_equal 1, duration[:seconds]
+      assert_equal 234, duration[:milliseconds]
+      assert_equal 567, duration[:microseconds]
+      assert_equal 898, duration[:nanoseconds]
+
+      duration = ISO8601Duration.new("P1Y2M3W4DT5H6M7.008009010S").to_h
+      assert_equal 1, duration[:years]
+      assert_equal 2, duration[:months]
+      assert_equal 3, duration[:weeks]
+      assert_equal 4, duration[:days]
+      assert_equal 5, duration[:hours]
+      assert_equal 6, duration[:minutes]
+      assert_equal 7, duration[:seconds]
+      assert_equal 8, duration[:milliseconds]
+      assert_equal 9, duration[:microseconds]
+      assert_equal 10, duration[:nanoseconds]
+    end
+  end
+end


### PR DESCRIPTION
Implements methods on `Temporal::Duration` that don't depend on any other parts of the Temporal library, as described at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration#iso_8601_duration_format.